### PR TITLE
Updated through2 to version 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   "dependencies": {
     "JSONStream": "0.10.0",
     "hyperquest": "1.2.0",
-    "through2": "0.6.5"
+    "through2": "2.0.0"
   }
 }


### PR DESCRIPTION
:rocket:

through2 just published version 2.0.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 2 commits (ahead by 2, behind by 0).

- [6424ae6](https://github.com/rvagg/through2/commit/6424ae6178834bb978ce3c3c033fa2d0398b0e14): 2.0.0
- [a12997c](https://github.com/rvagg/through2/commit/a12997c5bd369eb7d4ebf01fa0b7daf8bc21b41d): update deps for a v2 release

See the [full diff](https://github.com/rvagg/through2/compare/ba4a87875f2c82323c10023e36f4ae4b386c1bf8...6424ae6178834bb978ce3c3c033fa2d0398b0e14).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>